### PR TITLE
fix: Windows compilation error in config_dir()

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -34,10 +34,9 @@ impl ConfigManager {
         #[cfg(target_os = "windows")]
         {
             // Use Windows APPDATA
-            dirs::config_dir()
+            Ok(dirs::config_dir()
                 .context("Failed to get Windows config directory")?
-                .join("claude-code-sync")
-                .into()
+                .join("claude-code-sync"))
         }
 
         #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]


### PR DESCRIPTION
## Summary

- Fixes compilation error on Windows in `ConfigManager::config_dir()` 
- The Windows code path used `.into()` instead of `Ok()` to return the `PathBuf`

## Problem

Building on Windows fails with:

```
error[E0277]: the trait bound `Result<PathBuf, anyhow::Error>: From<PathBuf>` is not satisfied
  --> src\config.rs:40:18
   |
40 |                 .into()
   |                  ^^^^ the trait `From<PathBuf>` is not implemented for `Result<PathBuf, anyhow::Error>`
```

## Solution

Wrap the `PathBuf` in `Ok()` to match the function's `Result<PathBuf>` return type, consistent with the Linux and macOS code paths.

## Testing

- Verified the fix compiles successfully on Windows 10/11
- Ran `cargo install --path .` successfully after the fix
