### PR TITLE
fix: convert recursive tree traversal to iterative to prevent stack overflow

### DIFF
--- a/src/merge.rs
+++ b/src/merge.rs
@@ -31,20 +31,27 @@ impl MessageNode {
         self.children.push(child);
     }
 
-    /// Recursively collects all entries in this subtree in depth-first order
+    /// Collects all entries in this subtree in depth-first order (iterative)
     fn collect_entries(&self) -> Vec<ConversationEntry> {
-        let mut entries = vec![self.entry.clone()];
+        let mut entries = Vec::new();
+        // Use an explicit stack instead of recursion to avoid stack overflow
+        // on deep conversation chains (300+ messages).
+        let mut stack: Vec<&MessageNode> = vec![self];
 
-        // Sort children by timestamp to maintain chronological order
-        let mut sorted_children = self.children.clone();
-        sorted_children.sort_by(|a, b| {
-            let a_ts = a.entry.timestamp.as_ref();
-            let b_ts = b.entry.timestamp.as_ref();
-            a_ts.cmp(&b_ts)
-        });
+        while let Some(node) = stack.pop() {
+            entries.push(node.entry.clone());
 
-        for child in &sorted_children {
-            entries.extend(child.collect_entries());
+            // Sort children by timestamp (reversed because stack is LIFO)
+            let mut sorted_children: Vec<&MessageNode> = node.children.iter().collect();
+            sorted_children.sort_by(|a, b| {
+                let a_ts = a.entry.timestamp.as_ref();
+                let b_ts = b.entry.timestamp.as_ref();
+                b_ts.cmp(&a_ts)
+            });
+
+            for child in sorted_children {
+                stack.push(child);
+            }
         }
 
         entries
@@ -255,24 +262,52 @@ impl<'a> SmartMerger<'a> {
                 .push(uuid.clone());
         }
 
-        // Build tree recursively
-        fn build_subtree(
-            uuid: &str,
+        // Build tree iteratively to avoid stack overflow on deep conversation
+        // chains (300+ messages with large JSON payloads per entry).
+        //
+        // Strategy: collect all reachable UUIDs from each root in top-down
+        // order, then assemble nodes bottom-up so each parent can own its
+        // children without recursion.
+        fn build_subtree_iterative(
+            root_uuid: &str,
             uuid_to_entry: &HashMap<String, ConversationEntry>,
             parent_to_children: &HashMap<Option<String>, Vec<String>>,
         ) -> MessageNode {
-            let entry = uuid_to_entry.get(uuid).unwrap().clone();
-            let mut node = MessageNode::new(entry);
+            // Phase 1: BFS to collect all UUIDs reachable from this root
+            let mut processing_order: Vec<String> = Vec::new();
+            let mut queue: std::collections::VecDeque<String> =
+                std::collections::VecDeque::new();
+            queue.push_back(root_uuid.to_string());
 
-            // Get children for this UUID
-            if let Some(child_uuids) = parent_to_children.get(&Some(uuid.to_string())) {
-                for child_uuid in child_uuids {
-                    let child_node = build_subtree(child_uuid, uuid_to_entry, parent_to_children);
-                    node.add_child(child_node);
+            while let Some(uuid) = queue.pop_front() {
+                processing_order.push(uuid.clone());
+                if let Some(child_uuids) = parent_to_children.get(&Some(uuid)) {
+                    for child_uuid in child_uuids {
+                        queue.push_back(child_uuid.clone());
+                    }
                 }
             }
 
-            node
+            // Phase 2: build nodes bottom-up (reverse BFS order ensures
+            // children are built before their parents)
+            let mut node_map: HashMap<String, MessageNode> = HashMap::new();
+
+            for uuid in processing_order.iter().rev() {
+                let entry = uuid_to_entry.get(uuid).unwrap().clone();
+                let mut node = MessageNode::new(entry);
+
+                if let Some(child_uuids) = parent_to_children.get(&Some(uuid.clone())) {
+                    for child_uuid in child_uuids {
+                        if let Some(child_node) = node_map.remove(child_uuid) {
+                            node.add_child(child_node);
+                        }
+                    }
+                }
+
+                node_map.insert(uuid.clone(), node);
+            }
+
+            node_map.remove(root_uuid).unwrap()
         }
 
         // Find root UUIDs (entries with no parent)
@@ -281,7 +316,8 @@ impl<'a> SmartMerger<'a> {
         // Build trees from each root
         let mut roots = Vec::new();
         for root_uuid in root_uuids {
-            let root_node = build_subtree(&root_uuid, &uuid_to_entry, &parent_to_children);
+            let root_node =
+                build_subtree_iterative(&root_uuid, &uuid_to_entry, &parent_to_children);
             roots.push(root_node);
         }
 


### PR DESCRIPTION
## Summary

Fixes #70 -- `pull` crashes with `thread 'main' has overflowed its stack` on repos with large session histories (~2000+ sessions, ~1000+ conflicts).

**Root cause:** `build_subtree()` and `collect_entries()` in `merge.rs` use unbounded recursion proportional to conversation chain depth. Sessions with 300+ messages and large JSON payloads (full assistant responses, tool results) blow the default stack -- even `RUST_MIN_STACK=64MB` doesn't help because each frame clones multi-KB `ConversationEntry` structs.

**Fix:** Convert both functions from recursive to iterative using heap-allocated data structures:

- `build_subtree` -> `build_subtree_iterative`: BFS collects UUIDs top-down, then assembles nodes bottom-up via `HashMap` (moves ownership instead of recursing)
- `collect_entries`: explicit `Vec<&MessageNode>` stack for DFS traversal (borrows instead of cloning children)

**Behavior is identical** -- same traversal order, same merge output. All 126 existing unit tests pass. Only `merge.rs` is changed.

## Test Results

Tested against a real sync repo:
- **2355 remote sessions, 2080 local sessions, 1091 conflicts**
- Before fix: crashes at ~80-90 merges every time, `RUST_MIN_STACK=64MB` didn't help
- After fix: all 1091 conflicts merged, clean exit code 0, no crash

```
$ cargo test --lib
running 126 tests
...
test result: ok. 126 passed; 0 failed; 0 ignored
```

(Integration tests have a pre-existing Windows compilation issue with `std::os::unix` -- unrelated to this change.)